### PR TITLE
Update Newtonsoft.Json & Octokit

### DIFF
--- a/src/GithubHelperTool/GithubHelperTool.csproj
+++ b/src/GithubHelperTool/GithubHelperTool.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Octokit" Version="0.37.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Octokit" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Primarily updating Octokit which was failing with a stack overflow error for the Int32 of the issue number.
Secondarily, Newtonsoft.Json has a vulnerability.

Fixes error:
![image](https://github.com/nkolev92/GithubHelperTool/assets/49205731/6a664fca-ee0d-42a4-a386-75baf90e9632)
